### PR TITLE
bugfix

### DIFF
--- a/Assets/Noitom/Scripts/Mocap/NeuronInstance.cs
+++ b/Assets/Noitom/Scripts/Mocap/NeuronInstance.cs
@@ -172,24 +172,24 @@ namespace Neuron
             return socketType == NeuronEnums.SocketType.TCP ? portTcp : portUdp;
         }
 
-		protected bool Connect()
-		{
+        protected bool Connect()
+        {
             //source = NeuronConnection.Connect( address, port, commandServerPort, socketType );
             source = MocapApiManager.RequareConnection(address, GetPortByConnectionType(), portUdpServer, socketType, skeletonType);
 
-            if ( source != null )
-			{
-                if(string.IsNullOrEmpty(avatarName))
-				    boundActor = source.AcquireActor( actorID );
+            if (source != null)
+            {
+                if (string.IsNullOrEmpty(avatarName))
+                    boundActor = source.AcquireActor(actorID, true);
                 else
-                    boundActor = source.AcquireActor(avatarName);
+                    boundActor = source.AcquireActor(avatarName, true);
                 RegisterCallbacks();
-			}
+            }
 
-			return source != null;
-		}
+            return source != null;
+        }
 
-		protected void Disconnect()
+        protected void Disconnect()
 		{
             //NeuronConnection.Disconnect( boundActor.owner );
             MocapApiManager.Disconnect(boundActor.owner);

--- a/Assets/Noitom/Scripts/Mocap/NeuronSource.cs
+++ b/Assets/Noitom/Scripts/Mocap/NeuronSource.cs
@@ -114,7 +114,13 @@ namespace Neuron
         //{
         //}
 
-        public NeuronActor AcquireActor(int actorID)
+        /// <summary> 
+        /// AcquireActor by actorID
+        /// </summary>
+        /// <param name="actorID">actorID</param>
+        /// <param name="isCreat">only creat can use it</param>
+        /// <returns></returns>
+        public NeuronActor AcquireActor(int actorID, bool isCreat = false)
         {
             lock (actorCreateDestroyLock)
             {
@@ -123,12 +129,20 @@ namespace Neuron
                 {
                     return actor;
                 }
-
-                actor = CreateActor(actorID);
+                if (isCreat)
+                {
+                    actor = CreateActor(actorID);
+                }
                 return actor;
             }
         }
-        public NeuronActor AcquireActor(string actorName)
+        /// <summary>
+        /// AcquireActor by actorName
+        /// </summary>
+        /// <param name="actorName">actorName</param>
+        /// <param name="isCreat">only creat can use it</param>
+        /// <returns></returns>
+        public NeuronActor AcquireActor(string actorName, bool isCreat = false)
         {
             lock (actorCreateDestroyLock)
             {
@@ -137,8 +151,10 @@ namespace Neuron
                 {
                     return actor;
                 }
-
-                actor = CreateActor(allActors.Count, actorName);
+                if (isCreat)
+                {
+                    actor = CreateActor(allActors.Count, actorName);
+                }
                 return actor;
             }
         }

--- a/Assets/Noitom/Scripts/Mocap/NeuronSource.cs
+++ b/Assets/Noitom/Scripts/Mocap/NeuronSource.cs
@@ -181,6 +181,7 @@ namespace Neuron
                     if (!string.IsNullOrEmpty(actorName))
                     {
                         actor.SetAvatarName(actorName);
+                        actor.SetAvatarIndex(-1);
                     }
                     allActors.Add(actorIndex, actor);
                     actorIndex++;


### PR DESCRIPTION
Q: when avatar name is empty or null ,avatar id can not drive avatar
A: AcquireActor function add isCreat(default is false) (only connect can use isCreat)